### PR TITLE
adding __init__.py for importing utils dir under sensenet package

### DIFF
--- a/sensenet/utils/__init__.py
+++ b/sensenet/utils/__init__.py
@@ -1,0 +1,2 @@
+from sensenet.utils.closer import Closer
+from sensenet.utils import reraise


### PR DESCRIPTION
Fixing `pip install sensenet` error 
```
from sensenet.utils import reraise
ModuleNotFoundError: No module named 'sensenet.utils'
```